### PR TITLE
ADD - Permitindo o CORS em todas rotas

### DIFF
--- a/src/main/java/com/example/olimpoapi/config/WebConfig.java
+++ b/src/main/java/com/example/olimpoapi/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.example.olimpoapi.config;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // Permite CORS em todas as rotas
+        .allowedOrigins("*") // Permite todas as origens
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+    }
+}


### PR DESCRIPTION
## Permitindo o CORS em todas as rotas
 
## Criando classe WebConfig no qual eu habilito o CORS para todas as rotas e os métodos (CRUD)
 
- **Motivação:** É necessário consumir a API na área restrita utilizando JavScript.
- **Mudanças:** Uma classe criada.
- **Testes:** Rodamos a API localmente depois das alterações feitas.
 
## Tipo de Mudança
 
- [ ] Bugfix
- [x] Nova funcionalidade
- [ ] Melhoria
- [ ] Refatoração
- [ ] Outro: [especifique]